### PR TITLE
#3 Always write a valid product againts xsd

### DIFF
--- a/src/Product/AbstractProduct.php
+++ b/src/Product/AbstractProduct.php
@@ -21,7 +21,7 @@ abstract class AbstractProduct
     /**
      * @var float
      */
-    private $price;
+    private $price = .0;
 
     /**
      * @var array

--- a/src/Xml/XmlProductFeedWriter.php
+++ b/src/Xml/XmlProductFeedWriter.php
@@ -47,9 +47,10 @@ class XmlProductFeedWriter implements Feed\ProductFeedWriterInterface
         $writer->endElement();
 
         $writer->endElement(); // catalog
-
         $writer->flush();
-        unset($writer);
+
+        // unlink object reference
+        unset($this->writer);
     }
 
     /**


### PR DESCRIPTION
We set a default price value to 0.0, which will generates a valid product node even if price property hab not be filled.