### PR TITLE
Ability to override attributes prefix for CSV format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
   "require-dev": {
     "psr/log": "^1.0",
     "fzaninotto/faker": "^1.7",
-    "shoppingfeed/feed-xml": "1.*"
+    "shoppingfeed/feed-xml": "^1.0"
   }
 }


### PR DESCRIPTION
- We can override attributes_ prefix for CSV format in case we don't need it : 

```php
Csv\CsvProductFeedWriter::setAttributesPrefix('prefix');
```

- We only write fields if they are filled, avoiding empty columns if not defined