### PR TITLE
Xml feed metadata contains only platform & agent (the rest is removed)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ $generator
 
 Currently, the library supports the following format:
 
-- `xml` : default, all features available
+- `xml` : default, all features available. Note that metadata is deactivated by default for http caching purpose.
 - `csv` : no support for feed attributes, platform and metadata. Shipping and discount are limited to the 1 item.
 
 The format can be defined like this

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ $generator
 
 Currently, the library supports the following format:
 
-- `xml` : default, all features available. Note that metadata is deactivated by default for http caching purpose.
+- `xml` : default, all features available.
 - `csv` : no support for feed attributes, platform and metadata. Shipping and discount are limited to the 1 item.
 
 The format can be defined like this

--- a/src/ProductFeedMetadata.php
+++ b/src/ProductFeedMetadata.php
@@ -94,6 +94,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @return \DateTimeInterface
      */
     public function getStartedAt()
@@ -102,6 +104,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @param \DateTimeInterface $startedAt
      */
     public function setStartedAt(\DateTimeInterface $startedAt)
@@ -110,6 +114,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @return \DateTimeInterface
      */
     public function getFinishedAt()
@@ -118,6 +124,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @param \DateTimeInterface $finishedAt
      */
     public function setFinishedAt(\DateTimeInterface $finishedAt)
@@ -149,6 +157,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @return int
      */
     public function getFilteredCount()
@@ -157,6 +167,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @return int
      */
     public function getWrittenCount()
@@ -165,6 +177,8 @@ class ProductFeedMetadata
     }
 
     /**
+     * @deprecated No longer used. Will be dropped in a future version.
+     *
      * @return int
      */
     public function getInvalidCount()

--- a/src/Xml/XmlProductFeedWriter.php
+++ b/src/Xml/XmlProductFeedWriter.php
@@ -36,6 +36,11 @@ class XmlProductFeedWriter implements Feed\ProductFeedWriterInterface
         $writer = $this->writer;
         $writer->endElement(); // products
 
+        $writer->startElement('metadata');
+        $writer->writeElement('platform', $metadata->getPlatform());
+        $writer->writeElement('agent', $metadata->getAgent());
+        $writer->endElement();
+
         $writer->endElement(); // catalog
         $writer->flush();
 

--- a/src/Xml/XmlProductFeedWriter.php
+++ b/src/Xml/XmlProductFeedWriter.php
@@ -36,16 +36,6 @@ class XmlProductFeedWriter implements Feed\ProductFeedWriterInterface
         $writer = $this->writer;
         $writer->endElement(); // products
 
-        $writer->startElement('metadata');
-        $writer->writeElement('platform', $metadata->getPlatform());
-        $writer->writeElement('agent', $metadata->getAgent());
-        $writer->writeElement('startedAt', $metadata->getStartedAt()->format('c'));
-        $writer->writeElement('finishedAt', $metadata->getFinishedAt()->format('c'));
-        $writer->writeElement('invalid', $metadata->getInvalidCount());
-        $writer->writeElement('ignored', $metadata->getFilteredCount());
-        $writer->writeElement('written', $metadata->getWrittenCount());
-        $writer->endElement();
-
         $writer->endElement(); // catalog
         $writer->flush();
 


### PR DESCRIPTION
Metadata in Xml feeds avoid http caching by default. So we remove the lines that are generating the xml elements.
Can be tested with `php tests/functional/products-random.php`