### PR TITLE
Fix compatibility with PHP 8.1 (calling `trim` on `null`)

### DIFF
--- a/src/Xml/XmlProductFeedWriter.php
+++ b/src/Xml/XmlProductFeedWriter.php
@@ -230,6 +230,6 @@ class XmlProductFeedWriter implements Feed\ProductFeedWriterInterface
             $content = Feed\xml_utf8_clean($content);
         }
 
-        return $this->writer->writeElement(trim($name), trim($content));
+        return $this->writer->writeElement(trim($name), trim((string) $content));
     }
 }


### PR DESCRIPTION
Fix case where empty strings are replaced by `null`, then passed to `trim`.