### PR TITLE
Remove composer > require-dev > psr/log unused dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ]
   },
   "require-dev": {
-    "psr/log": "^1.0",
     "fzaninotto/faker": "^1.7",
     "shoppingfeed/feed-xml": "^1.0"
   }


### PR DESCRIPTION
### Linked Issue
https://github.com/shoppingflux/php-feed-generator/issues/34

### Description
Remove composer > require-dev > psr/log unused dependency - this is NOT used, so it can be safely removed (and released as a minor version). 